### PR TITLE
fix: Spatial discontinuity in OUMVLP-Pose pkl extraction

### DIFF
--- a/misc/pretreatment_oumvlp_pose.py
+++ b/misc/pretreatment_oumvlp_pose.py
@@ -1,4 +1,6 @@
 import os
+import re
+import cv2
 import json
 import os.path as osp
 from tqdm import tqdm
@@ -8,13 +10,30 @@ import pickle
 '''
 How to use it?
     Script Example:
-    #python pretreamt_oumvlp_pose.py --datasetdir=<YOUR OUMVLP DATASET PATH> --dstdir=<YOUR TARGET PATH>
+        python pretreamt_oumvlp_pose.py \
+        --datasetdir=<YOUR OUMVLP DATASET PATH> \
+        --dstdir=<YOUR TARGET PATH> \
+        --siluset_dir=<YOUR OUMVLP SILU DATASET PATH>
 This code is used for Preprocess the OUMVLP Pose dataset json file into
 PKL file
-
-        Original Dataset
+        Original Silu Dataset
             input data format
-             alphapose(dataset_root)
+                Silhouette_000-00 (view-sequence)
+                    00001 (subject) 
+                        0001.png
+                        0002.png
+                        ...
+                    00002 (subject)
+                        0001.png
+                        0002.png
+                        ...
+                    ...
+                Silhouette_000-01 (view-sequence)
+                    ...
+            
+        Original Pose Dataset
+            input data format
+                alphapose(dataset_root)
                 00001(subject)
                     000_00(view-sequence)
                         0021_keypoint.json
@@ -24,7 +43,8 @@ PKL file
                     ...
                 00002(subject)
                     ...
-        Processed Dataset
+
+        Processed Pose Dataset
             outout data format
             alhpapose(dataset_root)
                 00001(subject)
@@ -51,12 +71,42 @@ def parse_option():
     #add
     parser.add_argument("--datasetdir",help="The dir of the pose dataset")
     parser.add_argument("--dstdir",help="Target dir")
+    parser.add_argument("--siluset_dir",type=str, default="",
+                        help="The dir of the origin oumvlp silu dataset")
     #groups
     opt = parser.parse_args()
+    
+    opt.datasetdir = osp.abspath(opt.datasetdir)
+    opt.siluset_dir = osp.abspath(opt.siluset_dir)
+    assert osp.exists(opt.datasetdir), f"The pose dataset({opt.datasetdir}) is not exists"
+    assert osp.exists(opt.siluset_dir), f"The silu dataset({opt.siluset_dir}) is not exists"
     #return
     return opt
 
-def Json2PKL(dataset_dir,dstdir):
+def pose_silu_match_score(pose: np.ndarray, silu: np.ndarray):
+    """Compute the sum of the pixel intensity on all joints in the silu image as the silu-pose matching score.
+
+    Args:
+        pose (np.ndarray): the pose data with shape (17,3)
+        silu (np.ndarray): the origin silu frame with shape (H,W) or (H,W,C)
+
+    Returns:
+        float: the matching score of given pose and silu
+    """
+    pose_coord = pose[:,:2].astype(np.int32)
+    
+    H, W, *_ = silu.shape
+    valid_joints = (pose_coord[:, 1] >=0) & (pose_coord[:, 1] < H) & \
+                   (pose_coord[:, 0] >=0) & (pose_coord[:, 0] < W)
+    if np.sum(valid_joints) == len(pose_coord):
+        # only calculate score for points that are inside the silu img
+        # use the sum of all joints' pixel intensity as the score
+        return np.sum(silu[pose_coord[:, 1], pose_coord[:, 0]])
+    else:
+        # if pose coord is out of bound, return -inf
+        return -np.inf
+
+def Json2PKL(dataset_dir,dstdir, siluset_dir):
     '''
     Convert the jsons into PKL
     See the Description above
@@ -73,9 +123,25 @@ def Json2PKL(dataset_dir,dstdir):
                 seq_path = osp.join(path_ViewSeq,seq)
                 with open(seq_path) as f:
                     data = json.load(f)
-                if len(data['people'])==0:
+                    
+                person_num = len(data['people'])
+                if person_num==0:
                     continue
-                pose = np.array(data["people"][0]["pose_keypoints_2d"]).reshape(-1,3)
+                elif person_num == 1:
+                    pose = np.array(data["people"][0]["pose_keypoints_2d"]).reshape(-1,3)
+                else:
+                    img_name = re.findall(r'\d{4}', osp.basename(seq_path))[-1] + '.png'
+                    img_path = osp.join(siluset_dir, f"Silhouette_{ViewSeq_.replace('_', '-')}", id_, img_name)
+                    if not os.path.exists(img_path):
+                        print(f'Pose reference silu({img_path}) not exists.')
+                        continue
+                    silu_img = cv2.imread(img_path, cv2.IMREAD_GRAYSCALE)
+                    
+                    person_poses = [np.array(p["pose_keypoints_2d"]).reshape(-1,3) for p in data['people']]
+                    max_score_idx = np.argmax([pose_silu_match_score(p, silu_img) for p in person_poses])
+                    
+                    pose = person_poses[max_score_idx]
+
                 frame_list.append(pose)
             if not frame_list:
                 null_name = path_ViewSeq.split('/')[-3:]
@@ -100,7 +166,7 @@ if __name__ == '__main__':
     #get the option
     opt = parse_option()
     #use the Json2PKL function
-    if Json2PKL(opt.datasetdir,opt.dstdir):
+    if Json2PKL(opt.datasetdir,opt.dstdir, opt.siluset_dir):
         datasetName = opt.datasetdir.split('/')[-1]
         print(f'Success! The dataset: {datasetName} has been Processed')
     else:


### PR DESCRIPTION
Hi 👋,

Thanks for making `GPGait` and `GPGait++` open-source. This is an outstanding achievement, contributing much to the model-based gait recognition!

## 🐞 Bug statement

Approximately one week ago, I detected a bug in the extraction of `OUMVLP-Pose` pkl data within the [OpenGait](https://github.com/ShiqiYu/OpenGait) framework. Subsequently, I submitted a PR to the maintainer. The relevant link is as follows: 

> https://github.com/ShiqiYu/OpenGait/pull/280
> 👆 It is highly recommended that you click to view it. That encompasses my **detailed description and visualization of the problem**.

In it, I described in detail the selection of multiple potential skeletons in the original `json` data. **Choosing the first one by default will cause obvious spatial displacement and other discontinuities in the extracted pkl skeleton sequence, thus significantly reducing the performance of the subsequent algorithms.**

I have also identified this issue within [FastPoseGait](https://github.com/BNU-IVC/FastPoseGait), specifically at `line 78` in `misc/pretreatment_oumvlp_pose.py`. Consequently, I am bringing this matter to your attention.

https://github.com/BNU-IVC/FastPoseGait/blob/5ed0c6fa3333eee6b75a4302b8d3cee60fa0b089/misc/pretreatment_oumvlp_pose.py#L65-L79

## 🔨 Fix statement

I have fixed this problem. My idea is: 

If there are multiple skeletons in the original json file, **calculate the pixel intensity sum of all the joints of each skeleton**_(what the added function `pose_silu_match_score` does)_ on the original silhouette image, and **select the one with the largest result** as the final skeleton data of the frame, instead of selecting the first one by default. 

This can ensure that the skeleton is always aligned with the silhouette, thus eliminating the spatial discontinuity.

> [!NOTE]
> It should be noted that, since the silhouette image is required as a reference, it is essential to make an additional application for the [silhouette set of OUMVLP](http://www.am.sanken.osaka-u.ac.jp/BiometricDB/GaitMVLP.html).

## 🧩 Others

If you have any questions, feel free to let me know anytime. 

Hoping that my proposal can be adopted soon and wish your project continuous progress and success!
